### PR TITLE
Change classname for faradey gem  error

### DIFF
--- a/lib/be_gateway/connection.rb
+++ b/lib/be_gateway/connection.rb
@@ -31,7 +31,7 @@ module BeGateway
     def send_request(method, path, params = nil)
       r = begin
             connection.public_send(method, path, params)
-          rescue Faraday::Error::ClientError => e
+          rescue Faraday::ClientError => e
             logger.error("Connection error to '#{path}': #{e}") if logger
 
             OpenStruct.new(

--- a/spec/be_gateway/checkout_spec.rb
+++ b/spec/be_gateway/checkout_spec.rb
@@ -154,7 +154,7 @@ describe BeGateway::Checkout do
 
     context 'Faraday client raises an error' do
       before do
-        allow_any_instance_of(Faraday::Connection).to receive(:public_send).and_raise(Faraday::Error::ClientError, "Houston, we've got a problem")
+        allow_any_instance_of(Faraday::Connection).to receive(:public_send).and_raise(Faraday::ClientError, "Houston, we've got a problem")
       end
 
       it 'returns an error response' do


### PR DESCRIPTION
Faraday::Error::ClientError to Faraday::ClientError
It was deprecated, and removed after version 1.0