### PR TITLE
Add charge method for the credit card charge service

### DIFF
--- a/lib/be_gateway/client.rb
+++ b/lib/be_gateway/client.rb
@@ -11,6 +11,11 @@ module BeGateway
       end
     end
 
+    def charge(params)
+      path = 'services/credit_cards/charges'
+      send_request('post', path, request: params)
+    end
+
     def finalize_3ds(params)
       path = "/process/#{params[:uid]}/return"
       send_request('post', path, params)

--- a/lib/be_gateway/version.rb
+++ b/lib/be_gateway/version.rb
@@ -1,3 +1,3 @@
 module BeGateway
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/spec/be_gateway/client_spec.rb
+++ b/spec/be_gateway/client_spec.rb
@@ -286,6 +286,21 @@ describe BeGateway::Client do
         end
       end
 
+      describe '#charge' do
+        subject { client.charge(request_params) }
+
+        it 'sends charge request' do
+          expect_any_instance_of(Faraday::Connection)
+            .to receive(:post)
+            .with(%r{services/credit_cards/charges}, anything)
+
+          subject
+
+          expect(subject.transaction['type']).to eq('authorization')
+          expect(subject.transaction['authorization']['auth_code']).to eq('654321')
+        end
+      end
+
       describe '#payment' do
         before do
           response_body['transaction'].tap do |hsh|


### PR DESCRIPTION
## What?
I've added support for the charge service.

## Why?
Charge service is a new functionality with its own endpoint and flow. The main goal is to unify payment types. For an instance, if you don't know what action to choose between payment and authorization, here it is.

## Else
 In the tests checked for authorization key in the response, cause response could contain both actions.