### PR TITLE
Fix broken test

### DIFF
--- a/spec/be_gateway/async_client_spec.rb
+++ b/spec/be_gateway/async_client_spec.rb
@@ -127,7 +127,7 @@ describe BeGateway::AsyncClient do
 
         expect(res.status).to eq(425)
         expect(res.successful?).to eq(false)
-        expect(res.failed?).to eq(true)
+        expect(res.failed?).to eq(false)
         expect(res.processing?).to eq(true)
       end
     end


### PR DESCRIPTION
What?
Fix broken spec.

Why?
Seems, it is a typo, cause response can't be in failed and processing state at the same time.