### PR TITLE
bugfix: proxy usage

### DIFF
--- a/lib/be_gateway/connection.rb
+++ b/lib/be_gateway/connection.rb
@@ -60,7 +60,7 @@ module BeGateway
       @connection ||= Faraday::Connection.new(url, opts || {}) do |conn|
         conn.options[:open_timeout] ||= DEFAULT_OPEN_TIMEOUT
         conn.options[:timeout] ||= DEFAULT_TIMEOUT
-        conn.options[:proxy] = proxy if proxy
+        conn.proxy   ||= proxy if proxy # we use ||= to keep proxy passed within options
         conn.headers = passed_headers if passed_headers
         conn.request :json
         conn.request :basic_auth, login, password


### PR DESCRIPTION
proxy is read from options before the block's call
so setting it to options within a block has no effect
it should be set using a setter instead